### PR TITLE
fix: windows下非C盘无法创建模板文件 #54

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,16 @@
           "command": "MiniProgram.commands.create.component",
           "group": "file"
         }
+      ],
+      "commandPalette": [
+        {
+          "command": "MiniProgram.commands.create.page",
+          "when": "false"
+        },
+        {
+          "command": "MiniProgram.commands.create.component",
+          "when": "false"
+        }
       ]
     },
     "commands": [

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -41,7 +41,7 @@ async function create(type: 'page' | 'component', value: string, uri: vscode.Uri
     }
   } else {
     // 组件直接生成
-    generateTemplateFile()
+    await generateTemplateFile()
   }
 
   vscode.window.showInformationMessage(name + ' ' + value + ' 创建成功');


### PR DESCRIPTION
1. 在windows下，`vscode.Uri.parse(e.fsPath);` 重新创建的uri对象会丢失uri.fsPath的盘符信息，右键menu事件拿到的e就是uri对象，可以直接使用
2. 隐藏命令面板中这两个命令的使用，防止错误的调用